### PR TITLE
docs: Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can also pass static values like numbers, strings, or functions.
 <x-number-input
     x-step="0.1"
     x-format="'9.99'"
-    x-onincrement="() => console.log('incremented')"
+    x-on:increment="() => console.log('incremented')"
 />
 ```
 


### PR DESCRIPTION
Fixes a typo in the documentation. 

Changed `x-onincrement` to `x-on:increment`.